### PR TITLE
Map some constants

### DIFF
--- a/mappings/net/minecraft/SharedConstants.mapping
+++ b/mappings/net/minecraft/SharedConstants.mapping
@@ -5,6 +5,16 @@ CLASS net/minecraft/class_155 net/minecraft/SharedConstants
 	FIELD field_16742 gameVersion Lcom/mojang/bridge/game/GameVersion;
 	FIELD field_25135 useChoiceTypeRegistrations Z
 		COMMENT Specifies whether Minecraft should use choice type registrations from the game's schema when entity types or block entity types are created.
+	FIELD field_29702 TICKS_PER_SECOND I
+	FIELD field_29703 TICKS_PER_MINUTE I
+	FIELD field_29704 TICKS_IN_DAY I
+	FIELD field_29719 DEFAULT_SERVER_PORT I
+	FIELD field_29729 CHUNK_SIZE I
+	FIELD field_29730 DEFAULT_WORLD_HEIGHT I
+	FIELD field_29731 COMMAND_BLOCK_MAX_COMMAND_LENGTH I
+	FIELD field_29732 DATA_VERSION I
+	FIELD field_29733 CURRENT_VERSION Ljava/lang/String;
+	FIELD field_29734 NEXT_MAJOR_VERSION Ljava/lang/String;
 	METHOD method_16673 getGameVersion ()Lcom/mojang/bridge/game/GameVersion;
 	METHOD method_31372 getProtocolVersion ()I
 	METHOD method_34872 setGameVersion (Lcom/mojang/bridge/game/GameVersion;)V

--- a/mappings/net/minecraft/SharedConstants.mapping
+++ b/mappings/net/minecraft/SharedConstants.mapping
@@ -7,14 +7,14 @@ CLASS net/minecraft/class_155 net/minecraft/SharedConstants
 		COMMENT Specifies whether Minecraft should use choice type registrations from the game's schema when entity types or block entity types are created.
 	FIELD field_29702 TICKS_PER_SECOND I
 	FIELD field_29703 TICKS_PER_MINUTE I
-	FIELD field_29704 TICKS_IN_DAY I
+	FIELD field_29704 TICKS_PER_GAME_DAY I
 	FIELD field_29719 DEFAULT_SERVER_PORT I
 	FIELD field_29729 CHUNK_SIZE I
 	FIELD field_29730 DEFAULT_WORLD_HEIGHT I
 	FIELD field_29731 COMMAND_BLOCK_MAX_COMMAND_LENGTH I
 	FIELD field_29732 DATA_VERSION I
 	FIELD field_29733 CURRENT_VERSION Ljava/lang/String;
-	FIELD field_29734 NEXT_MAJOR_VERSION Ljava/lang/String;
+	FIELD field_29734 CURRENT_MAJOR_VERSION Ljava/lang/String;
 	METHOD method_16673 getGameVersion ()Lcom/mojang/bridge/game/GameVersion;
 	METHOD method_31372 getProtocolVersion ()I
 	METHOD method_34872 setGameVersion (Lcom/mojang/bridge/game/GameVersion;)V

--- a/mappings/net/minecraft/SharedConstants.mapping
+++ b/mappings/net/minecraft/SharedConstants.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_155 net/minecraft/SharedConstants
 		COMMENT Specifies whether Minecraft should use choice type registrations from the game's schema when entity types or block entity types are created.
 	FIELD field_29702 TICKS_PER_SECOND I
 	FIELD field_29703 TICKS_PER_MINUTE I
-	FIELD field_29704 TICKS_PER_GAME_DAY I
+	FIELD field_29704 TICKS_PER_INGAME_DAY I
 	FIELD field_29719 DEFAULT_SERVER_PORT I
 	FIELD field_29729 CHUNK_SIZE I
 	FIELD field_29730 DEFAULT_WORLD_HEIGHT I


### PR DESCRIPTION
I think I mapped most of the constants that can be identified. `field_29709` may be whether the version is a snapshot, since it's next to other version constants, is annotated with `@Deprecated` like them (and also is set to true).